### PR TITLE
sharing connection on same shard 

### DIFF
--- a/lib/activerecord/shard_for/shard_repository.rb
+++ b/lib/activerecord/shard_for/shard_repository.rb
@@ -9,6 +9,7 @@ module ActiveRecord
         @base_class = base_class
 
         @shards = cluster_config.connection_registry.each_with_object({}) do |(key, connection_name), hash|
+          generate_connection_publisher_unless_exist(connection_name)
           model = generate_model_for_shard(connection_name, key)
           base_class.const_set(:"#{generate_class_name(connection_name)}", model)
           hash[connection_name] = model
@@ -17,29 +18,50 @@ module ActiveRecord
 
       private
 
+      # Generate connection publisher to shard.
+      # More infomation, see `establish_connection to same shard` test in the model_spec.rb.
+      def generate_connection_publisher_unless_exist(connection_name)
+        class_name = generate_class_name(connection_name)
+
+        return if Object.const_defined?(:"#{class_name}")
+
+        model = Class.new(ActiveRecord::Base) do
+          module_eval <<-RUBY, __FILE__, __LINE__ + 1
+            def self.name
+              "#{class_name}"
+            end
+          RUBY
+        end
+        Object.const_set(:"#{class_name}", model)
+        model.establish_connection connection_name
+      end
+
       # @param [Symbol] connection_name
       # @param [Range] slot_range
       # @return [Class] A sub class of given AR model.
       #   A sub class has connection setting for specific shard.
-      def generate_model_for_shard(connection_name, key)
+      def generate_model_for_shard(connection_name, key) # rubocop:disable Metrics/MethodLength
         class_name = generate_class_name(connection_name)
 
-        model = Class.new(base_class) do
+        Class.new(base_class) do
           self.table_name = base_class.table_name
           class << self
             attr_reader :assigned_key
           end
           @assigned_key = key
+          # For Rails5.0 only
+          self.connection_specification_name = class_name if respond_to?(:connection_specification_name)
 
           module_eval <<-RUBY, __FILE__, __LINE__ + 1
             def self.name
               "#{base_class.name}::#{class_name}"
             end
+
+            def self.connection
+              ::#{class_name}.connection
+            end
           RUBY
         end
-
-        model.class_eval { establish_connection(connection_name) }
-        model
       end
     end
   end

--- a/lib/activerecord/shard_for/shard_repository.rb
+++ b/lib/activerecord/shard_for/shard_repository.rb
@@ -57,8 +57,8 @@ module ActiveRecord
               "#{base_class.name}::#{class_name}"
             end
 
-            def self.connection
-              ::#{class_name}.connection
+            def self.retrieve_connection
+              ::#{class_name}.retrieve_connection
             end
           RUBY
         end

--- a/spec/activerecord/shard_for/model_spec.rb
+++ b/spec/activerecord/shard_for/model_spec.rb
@@ -170,6 +170,10 @@ RSpec.describe ActiveRecord::ShardFor::Model do
   end
 
   describe 'establish_connection to same shard' do
+    before do
+      ActiveRecord::Base.clear_all_connections!
+    end
+
     it 'uses same connection' do
       aggregate_failures do
         (0..3).to_a.each do |n|
@@ -182,7 +186,16 @@ RSpec.describe ActiveRecord::ShardFor::Model do
             publisher_class.connection
           ]
           expect(connections).to all be_present
+
+          connection_pools = [
+            Account.using(n).connection_pool,
+            Character.using(n).connection_pool,
+            Item.using(n).connection_pool,
+            publisher_class.connection_pool
+          ]
+
           expect(connections.uniq.length).to eq 1
+          expect(connection_pools.uniq.length).to eq 1
           expect(publisher_class.connection).not_to eq Product.using(n).connection
         end
       end

--- a/spec/activerecord/shard_for/model_spec.rb
+++ b/spec/activerecord/shard_for/model_spec.rb
@@ -173,13 +173,17 @@ RSpec.describe ActiveRecord::ShardFor::Model do
     it 'uses same connection' do
       aggregate_failures do
         (0..3).to_a.each do |n|
+          publisher_class = ShardForTestCharacter001 # eq Account.using(n).name.demodulize
+
           connections = [
             Account.using(n).connection,
             Character.using(n).connection,
-            Item.using(n).connection
+            Item.using(n).connection,
+            publisher_class.connection
           ]
           expect(connections).to all be_present
           expect(connections.uniq.length).to eq 1
+          expect(publisher_class.connection).not_to eq Product.using(n).connection
         end
       end
     end

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -63,10 +63,22 @@ class UserReadonly < ActiveRecord::Base
   replicates_with master: :User
 end
 
+class Account < ActiveRecord::Base
+  include ActiveRecord::ShardFor::Model
+  use_cluster :character, :hash_modulo
+  def_distkey :name
+end
+
 class Character < ActiveRecord::Base
   include ActiveRecord::ShardFor::Model
   use_cluster :character, :distkey
   def_distkey :shard_no
+end
+
+class Item < ActiveRecord::Base
+  include ActiveRecord::ShardFor::Model
+  use_cluster :character, :hash_modulo
+  def_distkey :name
 end
 
 class Product < ActiveRecord::Base

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -7,9 +7,22 @@ ActiveRecord::Schema.define(version: 0) do
     t.datetime 'updated_at',   null: false
   end
 
+  create_table 'accounts', force: :cascade do |t|
+    t.string   'name',         null: false
+    t.string   'password',     null: false
+    t.datetime 'created_at',   null: false
+    t.datetime 'updated_at',   null: false
+  end
+
   create_table 'characters', force: :cascade do |t|
     t.string   'name',         null: false
     t.integer  'shard_no'
+    t.datetime 'created_at',   null: false
+    t.datetime 'updated_at',   null: false
+  end
+
+  create_table 'items', force: :cascade do |t|
+    t.string   'name',         null: false
     t.datetime 'created_at',   null: false
     t.datetime 'updated_at',   null: false
   end


### PR DESCRIPTION
Please reference this failure test for this problem.
https://github.com/yuemori/activerecord-shard_for/blob/1410bc96ceaa46e7fc6b92d4ca4ba39bb273256d/spec/activerecord/shard_for/model_spec.rb#L172-L223

Implement connection publisher class and delegate connection for publisher class in shards to solve this.