### PR TITLE
Allow settings `thread_pool_base_size` and command executor

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,9 @@ Layout/FileName:
 Metrics/MethodLength:
   Max: 15
 
+Metrics/AbcSize:
+  Max: 20
+
 Style/ParallelAssignment:
   Enabled: false
 

--- a/spec/activerecord/shard_for/all_shards_in_parallel_spec.rb
+++ b/spec/activerecord/shard_for/all_shards_in_parallel_spec.rb
@@ -2,7 +2,17 @@ require 'spec_helper'
 
 RSpec.describe ActiveRecord::ShardFor::AllShardsInParallel do
   let(:model_class) { User }
-  let(:instance) { described_class.new(model_class.all_shards) }
+  let(:instance) { described_class.new(model_class.all_shards, service: service) }
+  let(:service) { Expeditor::Service.new(executor: executor) }
+  let(:executor) do
+    thread_size = model_class.all_shards.size * 100
+    Concurrent::ThreadPoolExecutor.new(
+      min_threads: thread_size,
+      max_threads: thread_size,
+      max_queue: model_class.all_shards.size,
+      fallback_policy: :abort
+    )
+  end
 
   describe '#map' do
     it 'maps in parallel' do


### PR DESCRIPTION
We project was encounted to `ActiveRecord::ConnectionTimeoutError` . This error means 
the maximum number of connection pool has been reached.
see: https://github.com/rails/rails/blob/v5.1.6/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L491-L493

This PR makes setting `thread_pool_base_size` and `Expeditor::Command` executor, to can afford and predict to the number of threads at runtime.

it is necessary to specify `thread_pool_base_size` according to the number of server threads when thread-based application server to be used (e.g. puma).

see:

- https://github.com/cookpad/mixed_gauge/pull/7
- https://github.com/cookpad/mixed_gauge/pull/8