### PR TITLE
Fix establish_connection is called on class loading

### DIFF
--- a/activerecord-shard_for.gemspec
+++ b/activerecord-shard_for.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'appraisal'
-  spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'sqlite3', '~> 1.3.6'
   spec.add_development_dependency 'rspec-parameterized'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0.0'
 end

--- a/lib/activerecord/shard_for/model.rb
+++ b/lib/activerecord/shard_for/model.rb
@@ -69,6 +69,7 @@ module ActiveRecord
         # @raise [ActiveRecord::ShardFor::MissingDistkeyAttribute]
         def put!(attributes)
           raise '`distkey` is not defined. Use `def_distkey`.' unless distkey
+
           @before_put_callback.call(attributes) if defined?(@before_put_callback) && @before_put_callback
 
           key = fetch_distkey_from_attributes(attributes)

--- a/lib/activerecord/shard_for/shard_repository.rb
+++ b/lib/activerecord/shard_for/shard_repository.rb
@@ -9,7 +9,6 @@ module ActiveRecord
         @base_class = base_class
 
         @shards = cluster_config.connection_registry.each_with_object({}) do |(key, connection_name), hash|
-          establish_connection(connection_name)
           model = generate_model_for_shard(connection_name, key)
           base_class.const_set(:"#{generate_shard_name(connection_name)}", model)
           hash[connection_name] = model
@@ -17,24 +16,6 @@ module ActiveRecord
       end
 
       private
-
-      # Establish connection for shard.
-      # @param [Symbol] connection_name
-      def establish_connection(connection_name)
-        shard_name = generate_shard_name(connection_name)
-
-        model = Class.new(base_class) do
-          self.table_name = base_class.table_name
-
-          module_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def self.name
-              "#{shard_name}"
-            end
-          RUBY
-        end
-
-        model.establish_connection connection_name
-      end
 
       # @param [Symbol] connection_name
       # @param [Range] slot_range

--- a/spec/activerecord/shard_for/cluster_config_spec.rb
+++ b/spec/activerecord/shard_for/cluster_config_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe ActiveRecord::ShardFor::ClusterConfig do
+  let(:cluster_config) { ActiveRecord::ShardFor.config.fetch_cluster_config(cluster_name) }
+
   describe '#fetch' do
     subject { cluster_config.fetch(key) }
-
-    let(:cluster_config) { ActiveRecord::ShardFor.config.fetch_cluster_config(cluster_name) }
 
     context 'when key is not range' do
       let(:cluster_name) { :user }
@@ -38,5 +38,16 @@ RSpec.describe ActiveRecord::ShardFor::ClusterConfig do
         it { is_expected.to eq connection }
       end
     end
+  end
+
+  describe 'establish_connection' do
+    it { expect(Object.const_defined?(:ShardForTestCharacter001)).to be_truthy }
+    it { expect(Object.const_defined?(:ShardForTestCharacter002)).to be_truthy }
+    it { expect(Object.const_defined?(:ShardForTestCharacter003)).to be_truthy }
+
+    it { expect(Character.using(0).connection).to eq CharacterAnother.using(0).connection }
+    it { expect(Character.using(1).connection).to eq CharacterAnother.using(1).connection }
+    it { expect(Character.using(2).connection).to eq CharacterAnother.using(2).connection }
+    it { expect(Character.using(2).connection).to eq CharacterAnother.using(2).connection }
   end
 end

--- a/spec/activerecord/shard_for/database_tasks_spec.rb
+++ b/spec/activerecord/shard_for/database_tasks_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe ActiveRecord::ShardFor::DatabaseTasks do
 
   describe '#cluster_names' do
     it 'retuns an Array of cluster name' do
-      expect(described_class.cluster_names).to eq(%i(user user_readonly character product))
+      expect(described_class.cluster_names).to match_array(%i(user user_readonly character character_another product))
     end
   end
 
   describe '#clusters' do
     it 'retuns an Array of cluster config' do
       result = described_class.clusters
-      expect(result.size).to eq(4)
+      expect(result.size).to eq(5)
       expect(result).to all(a_kind_of(ActiveRecord::ShardFor::ClusterConfig))
     end
   end

--- a/spec/activerecord/shard_for/model_spec.rb
+++ b/spec/activerecord/shard_for/model_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe ActiveRecord::ShardFor::Model do
 
   let(:user_attributes) { { name: 'Alice', email: 'alice@example.com' } }
 
+  let(:cluster_config) { ActiveRecord::ShardFor.config.fetch_cluster_config(:user) }
+
+  it { expect(ActiveSupport::DescendantsTracker.descendants(model).count).to eq cluster_config.connections.count }
+
   describe '.put!' do
     it 'creates new record into proper node' do
       record = model.put!(user_attributes)

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -40,6 +40,12 @@ ActiveRecord::ShardFor.configure do |config|
     cluster.register(200..Float::INFINITY, :test_character_003)
   end
 
+  config.define_cluster(:character_another) do |cluster|
+    cluster.register(0, :test_character_001)
+    cluster.register(1, :test_character_002)
+    cluster.register(2, :test_character_003)
+  end
+
   config.define_cluster(:product) do |cluster|
     cluster.register(0, :test_product_001)
     cluster.register(1, :test_product_002)
@@ -70,6 +76,12 @@ class Account < ActiveRecord::Base
 end
 
 class Character < ActiveRecord::Base
+  include ActiveRecord::ShardFor::Model
+  use_cluster :character, :distkey
+  def_distkey :shard_no
+end
+
+class CharacterAnother < ActiveRecord::Base
   include ActiveRecord::ShardFor::Model
   use_cluster :character, :distkey
   def_distkey :shard_no


### PR DESCRIPTION
`include ActiveRecord::ShardFor::Model` evaluate on class loading, and 
at the same time establish_conenction is called.

This behaviour causes some problems. For examples, establish_connection called in transaction.

This problem occurs when autoload is enabled. 