### PR TITLE
Fix set_callback raises NoMethodError when already defined callback.

### DIFF
--- a/lib/activerecord/shard_for/patch.rb
+++ b/lib/activerecord/shard_for/patch.rb
@@ -10,6 +10,20 @@ module ActiveRecord
           super
           shard_repository.all.each { |shard| shard.defined_enums = defined_enums }
         end
+
+        # For ActiveSupport::Callbacks patch.
+        #
+        # Since define_callbacks has not been successfully propagated to the shard class when called,
+        # we also call define_callback of the shard class.
+        def define_callbacks(*args)
+          if abstract_class
+            all_shards.each do |model|
+              model.define_callbacks(*args)
+            end
+          end
+
+          super
+        end
       end
     end
   end

--- a/spec/activerecord/shard_for/patch_spec.rb
+++ b/spec/activerecord/shard_for/patch_spec.rb
@@ -20,6 +20,9 @@ RSpec.describe ActiveRecord::ShardFor::Patch do
       before_put do |attrs|
         attrs[:name] = generate_name unless attrs[:name]
       end
+
+      define_callbacks :sample_callback
+      set_callback :sample_callback, :before, :hoge
     end
   end
 
@@ -27,5 +30,13 @@ RSpec.describe ActiveRecord::ShardFor::Patch do
     subject { model.defined_enums }
 
     it { is_expected.not_to be_empty }
+  end
+
+  describe 'callbacks' do
+    before do
+      model.define_callbacks :sample_callback2
+    end
+
+    it { expect { model.set_callback :sample_callback2, :before, :email }.not_to raise_error }
   end
 end


### PR DESCRIPTION
## For Example

see test case.

## Cause

Since define_callbacks has not been successfully propagated to the shard class when called, we also call define_callback of the shard class.
Bacause `ActiveSupport::Callbacks` registerd to callbacks to `__callbacks` method, `__callbacks` was implemented by `class_attribute` , and `class_attribute` was behaved to redefine method when writer method called.
Probably sharding class already called `__callbacks`.